### PR TITLE
Add `appName` and `appUrl`

### DIFF
--- a/jupyter-lite.json
+++ b/jupyter-lite.json
@@ -1,0 +1,7 @@
+{
+  "jupyter-lite-schema-version": 0,
+  "jupyter-config-data": {
+    "appName": "SymPy Live",
+    "appUrl": "./repl"
+  }
+}


### PR DESCRIPTION
`appUrl` will help redirect https://www.sympy.org/live to https://www.sympy.org/live/repl/index.html when `/repl` is not specified directly in the URL.
