### PR TITLE
Update demo link in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ files used by the new SymPy Live. The code is deployed as a static site to GitHu
 
 ## ✨ Try it in your browser ✨
 
-- **https://ivanistheone.github.io/live/repl/index.html**
+- **https://sympy.github.io/live/repl/index.html?toolbar=1&kernel=python**
 
 
 ## Requirements


### PR DESCRIPTION
Now that the repo has been moved to the `sympy` organization: https://sympy.github.io/live/repl/index.html?toolbar=1&kernel=python