### PR TITLE
Disable the plotly widget extension

### DIFF
--- a/jupyter-lite.json
+++ b/jupyter-lite.json
@@ -2,6 +2,9 @@
   "jupyter-lite-schema-version": 0,
   "jupyter-config-data": {
     "appName": "SymPy Live",
-    "appUrl": "./repl"
+    "appUrl": "./repl",
+    "disabledExtensions": [
+      "@jupyter-widgets/jupyterlab-manager"
+    ],
   }
 }

--- a/jupyter-lite.json
+++ b/jupyter-lite.json
@@ -5,6 +5,6 @@
     "appUrl": "./repl",
     "disabledExtensions": [
       "@jupyter-widgets/jupyterlab-manager"
-    ],
+    ]
   }
 }

--- a/jupyter-lite.json
+++ b/jupyter-lite.json
@@ -4,7 +4,8 @@
     "appName": "SymPy Live",
     "appUrl": "./repl",
     "disabledExtensions": [
-      "@jupyter-widgets/jupyterlab-manager"
+      "@jupyter-widgets/jupyterlab-manager",
+      "jupyterlab-plotly"
     ]
   }
 }


### PR DESCRIPTION
Fixes https://github.com/jupyterlite/jupyterlite/issues/635

This will disable the extension causing the error printed in the dev tools console, as reported in https://github.com/jupyterlite/jupyterlite/issues/635.

Using the `disabledExtensions` config that works in JupyterLite like in JupyterLab: https://jupyterlab.readthedocs.io/en/stable/user/extensions.html?#enabling-and-disabling-extensions