### PR TITLE
Switch to memory storage for the repl

### DIFF
--- a/jupyter-lite.json
+++ b/jupyter-lite.json
@@ -6,6 +6,9 @@
     "disabledExtensions": [
       "@jupyter-widgets/jupyterlab-manager",
       "jupyterlab-plotly"
-    ]
+    ],
+    "enableMemoryStorage": true,
+    "settingsStorageDrivers": ["memoryStorageDriver"],
+    "contentsStorageDrivers": ["memoryStorageDriver"]
   }
 }


### PR DESCRIPTION
A small config tweak to default to memory storage for the user settings and content.

This usually makes sense for ephemeral sessions and apps like the `repl`.

See https://jupyterlite.readthedocs.io/en/latest/howto/configure/storage.html#volatile-memory-storage for more information.