### PR TITLE
Update requirements.txt to match changes in jupyterlite/demo

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: '3.10'
       - name: Install the dependencies
         run: |
           python -m pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-jupyterlab~=3.3.0
-jupyterlite==0.1.0b7
+jupyterlab~=3.5.1
+jupyterlite==0.1.0b17


### PR DESCRIPTION
In issue https://github.com/sympy/live/issues/14 @sylee957 reports that the live shell is currently using an old version of sympy.

I tried triggering CI pipeline with [this commit](https://github.com/sympy/live/commit/aea7512992d536491b1ebf5643885ca5983e0777) hoping this would include the latest version in the build, but that didn't do it (the sympy import is done at load time).

I'm therefore trying this new approach in this PR, which is to update the version of jupyterlite and jupyterlab we're using, to match what was done in the [jupyterlite/demo/ commits](https://github.com/jupyterlite/demo/commits/main):
 - https://github.com/jupyterlite/demo/pull/99/files#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3
 - https://github.com/jupyterlite/demo/pull/102/files
 - https://github.com/jupyterlite/demo/pull/103/files
