### PR TITLE
Build with JupyterLite 0.5.0 + Pyodide kernel 0.5.1, plus miscellaneous JupyterLite REPL updates

### DIFF
--- a/jupyter_lite_config.json
+++ b/jupyter_lite_config.json
@@ -1,6 +1,7 @@
 {
   "LiteBuildConfig": {
     "apps": ["repl"],
-    "no_unused_shared_packages": true
+    "no_unused_shared_packages": true,
+    "no_sourcemaps": true
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 # Core modules and Pyodide kernel (mandatory)
-# Pyodide kernel versions 0.4.7 and 0.5.0 come with
-# Pyodide 0.27, with SymPy 1.13.3, respectively:
+# Pyodide kernel version 0.5.1 comes with Pyodide 0.27.1
+# which in-turn comes with SymPy 1.13.3:
 # https://jupyterlite-pyodide-kernel.readthedocs.io/en/stable/#compatibility
 # https://pyodide.org/en/stable/usage/packages-in-pyodide.html
 # We constrain/pin them to avoid breaking changes on rebuilds.
 jupyterlite-core>=0.5.0,<0.6.0
-jupyterlite-pyodide-kernel==0.5.0
+jupyterlite-pyodide-kernel==0.5.1
 
 # Specific to generating SymPy Live index page
 jinja2==3.1.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,11 @@
-# Core modules (mandatory)
-jupyterlab~=4.2.5
-jupyterlite-core>=0.4.5,<0.5
-
-# Python kernel (optional)
-jupyterlite-pyodide-kernel>=0.4.7,<0.5
+# Core modules and Pyodide kernel (mandatory)
+# Pyodide kernel versions 0.4.7 and 0.5.0 come with
+# Pyodide 0.27, with SymPy 1.13.3, respectively:
+# https://jupyterlite-pyodide-kernel.readthedocs.io/en/stable/#compatibility
+# https://pyodide.org/en/stable/usage/packages-in-pyodide.html
+# We constrain/pin them to avoid breaking changes on rebuilds.
+jupyterlite-core>=0.5.0,<0.6.0
+jupyterlite-pyodide-kernel==0.5.0
 
 # Specific to generating SymPy Live index page
 jinja2==3.1.5

--- a/templates/index.html
+++ b/templates/index.html
@@ -92,7 +92,7 @@
           {% trans %}Press ENTER to run the code or use the Run button in the toolbar.{% endtrans %}
         </p>
         <p id="loading_message">
-          {% trans %}Note it can take up to 30 seconds before the shell finishes loading and is ready to run commands.{% endtrans %}    
+          {% trans %}Note it can take up to 30 seconds before the shell finishes loading and is ready to run commands.{% endtrans %}
         </p>
       </div>
   </div>
@@ -120,7 +120,7 @@
   </p>
   <p>
     {% trans %}SymPy Live shell is powered by{% endtrans %} <a href="https://jupyterlite.readthedocs.io/en/latest/">JupyterLite</a>.
-    {% trans %}It can take up to 30 seconds before the shell code and libraries load completely and become available for using interactively.{% endtrans %}    
+    {% trans %}It can take up to 30 seconds before the shell code and libraries load completely and become available for using interactively.{% endtrans %}
   </p>
 </div>
 
@@ -141,7 +141,7 @@
       </p>
 
       <p>
-        {% trans %}Read the tutorial in the SymPy docs to learn more about SymPy{% endtrans %}: 
+        {% trans %}Read the tutorial in the SymPy docs to learn more about SymPy{% endtrans %}:
         <a href="https://docs.sympy.org/tutorial/">{% trans %}SymPy Tutorial{% endtrans %}</a>.
       </p>
   </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -119,7 +119,7 @@
     </pre>
   </p>
   <p>
-    {% trans %}SymPy Live shell is powered by{% endtrans %} <a href="https://jupyterlite.readthedocs.io/en/latest/">JupyterLite</a>.
+    {% trans %}SymPy Live shell is powered by{% endtrans %} <a href="https://jupyterlite.readthedocs.io/en/stable/">JupyterLite</a>.
     {% trans %}It can take up to 30 seconds before the shell code and libraries load completely and become available for using interactively.{% endtrans %}
   </p>
 </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -46,7 +46,7 @@
   $(document).ready(function() {
     // default iframe src with SymPy initcode
     // see https://jupyterlite.readthedocs.io/en/stable/quickstart/embed-repl.html#configuration for URL customisation
-    var iframe_src = "{{ host }}{{ path }}{{ query }}?kernel=python&execute=0?toolbar=1&code={{ initcode|urlencode }}";
+    var iframe_src = "{{ host }}{{ path }}{{ query|safe }}&code={{ initcode|urlencode }}";
     // check if we have additional statements to evaluate in the query string
     var statements = getURLParameter('evaluate');
     if (statements) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -45,7 +45,8 @@
 
   $(document).ready(function() {
     // default iframe src with SymPy initcode
-    var iframe_src = "{{ host }}{{ path }}{{ query }}&code={{ initcode|urlencode }}";
+    // see https://jupyterlite.readthedocs.io/en/stable/quickstart/embed-repl.html#configuration for URL customisation
+    var iframe_src = "{{ host }}{{ path }}{{ query }}?kernel=python&execute=0?toolbar=1&code={{ initcode|urlencode }}";
     // check if we have additional statements to evaluate in the query string
     var statements = getURLParameter('evaluate');
     if (statements) {


### PR DESCRIPTION
## Description

This PR updates the SymPy Live shell so that the deployment can be built with JupyterLite 0.5.0 (upper-pinned to 0.6.0, matching that of `jupyterlite-pyodide-kernel`). `jupyterlite-pyodide-kernel` has been bumped to 0.5.1. which is slightly more reliable and a bit faster; it bumps to Pyodide 0.27.1 (which retains SymPy 1.13.3, similar to Pyodide 0.27.0). An inline comment with links to the documentation has been added as a compatibility note if we want to update the versions further with upcoming Pyodide releases.

On the REPL side, JupyterLite brings [a new `?execute=0` URL parameter](https://jupyterlite.readthedocs.io/en/latest/quickstart/embed-repl.html#populate-the-prompt-without-executing) that populates the prompt with the SymPy initialisation code snippet, without executing it. This should be helpful with saving bandwidth on the load, as the code won't run automatically until the user presses Enter. `&toolbar=1` and `&kernel=python` have been added explicitly rather than implicitly to guard against any possible breaking changes upstream, and they control the visibility of the toolbar with the kernel options (Run/Restart/Clear) and perform the auto-selection of the kernel respectively.

The [JupyterLite source maps](https://jupyterlite.readthedocs.io/en/stable/reference/api/py/jupyterlite-core.html#jupyterlite_core.config.LiteBuildConfig.no_sourcemaps) have also been disabled, which makes the JupyterLite deployment come down by 70.9% from 56 MiB to 16.3 MiB. This has also been applied for SymPy's interactive docs in https://github.com/sympy/sympy/pull/27419 and was inspired by https://github.com/scikit-learn/scikit-learn/pull/26246.
