### PR TITLE
Fix `save-state` deprecation warning, pin GitHub Actions to their SHAs, and remove unneeded steps

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,8 +61,6 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2.3.1
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: jupyterlite-demo-dist-${{ github.run_number }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -50,7 +50,7 @@ jobs:
         run: echo "live.sympy.org" > ./_output/CNAME
 
       - name: Upload (dist)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: jupyterlite-demo-dist-${{ github.run_number }}
           path: ./_output
@@ -63,14 +63,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.1
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: jupyterlite-demo-dist-${{ github.run_number }}
           path: ./dist
           merge-multiple: true
 
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@4.1.3
+        uses: JamesIves/github-pages-deploy-action@15de0f09300eea763baee31dff6c6184995c5f6a # v4.7.2
         with:
           branch: gh-pages
           folder: dist


### PR DESCRIPTION
## Description

This PR brings a few short updates for the deployment workflow:
- Updated to JamesIves/github-pages-deploy-action@4.7.2 to resolve a [warning about the deprecation of `save-state`](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands), coming from its older version.
- Pinned GitHub Actions to their specific commit SHAs.
- Removed a checkout step for the `deploy:` job, since it is not needed for the deployment. It was needed only for the JupyterLite builds in the previous job.