### PR TITLE
chore: add Dependabot for GitHub Actions and `pip` dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# GitHub Dependabot configuration file. References:
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: /
+    groups:
+      github-actions:
+        patterns:
+          - "*" # Group all Actions updates into a single larger pull request
+    schedule:
+      interval: monthly
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: monthly


### PR DESCRIPTION
## Description

This PR closes #31. I've configured Dependabot to update the GitHub Actions dependencies. I'm usually opposed to Dependabot updating `pip`-dependencies, but I think that would be fine here because #26 removed the rest of the dependencies and placed them in inline scripts, so we have just two dependencies: JupyterLite, and the Pyodide kernel.

> [!IMPORTANT]
> Dependabot would need to be enabled through the https://github.com/sympy/live/network/updates page by someone with administrator permissions for this repository before it starts checking for automated updates.