### PR TITLE
Fix broken deployments on iOS

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 # Core modules and Pyodide kernel (mandatory)
-# Pyodide kernel version 0.5.2 comes with Pyodide 0.27.1
+# Pyodide kernel version 0.6.0a4 comes with Pyodide 0.27.4
 # which in-turn comes with SymPy 1.13.3:
-# https://jupyterlite-pyodide-kernel.readthedocs.io/en/stable/#compatibility
-# https://pyodide.org/en/stable/usage/packages-in-pyodide.html
+# https://jupyterlite-pyodide-kernel.readthedocs.io/en/latest/#compatibility
+# https://pyodide.org/en/0.27.4/usage/packages-in-pyodide.html
 # We constrain/pin them to avoid breaking changes on rebuilds.
-jupyterlite-core>=0.5.0,<0.6.0
-jupyterlite-pyodide-kernel==0.5.2
+jupyterlite-core>=0.5.0,<0.6.0a4
+jupyterlite-pyodide-kernel==0.6.0a4


### PR DESCRIPTION
Closes #34; bumps to Pyodide 0.27.4 via https://github.com/jupyterlite/pyodide-kernel/releases/tag/v0.6.0a4. The problem was raised in https://github.com/pyodide/pyodide/issues/5428 and fixed with Pyodide 0.27.3 via https://github.com/pyodide/pyodide/pull/5445.