### PR TITLE
Use `github-actions[bot]` for deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,3 +75,5 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages
           publish_dir: dist
+          user_name: "github-actions[bot]"
+          user_email: "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
The workflow has been using my credentials to deploy to the `[gh-pages](https://github.com/sympy/live/tree/gh-pages)` branch, which inflates my commit history as we deploy on a schedule. Additionally, these commits don't appear as "verified" as I sign my commits, and this can't happen without my SSH key.