### PR TITLE
Set `force_orphan: true` to reduce repository size

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,6 +74,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages
+          force_orphan: true
           publish_dir: dist
           user_name: "github-actions[bot]"
           user_email: "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
The repository size is 932.5 MiB, which is dangerously close to the limit where we would need to activate Git-LFS. I noticed that this is the case because we add the binary wheel to the repository in the `gh-pages` branch as a part of #26, which means that we've been growing exponentially since that happened (as we build the site everyday with a CRON job).

Setting the `force_orphan` input should resolve this: https://github.com/peaceiris/actions-gh-pages/tree/4f9cc6602d3f66b9c108549d475ec49e8ef4d45e/?tab=readme-ov-file#%EF%B8%8F-force-orphan-force_orphan. 