### PR TITLE
Fix footer text colour on light mode

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -3,6 +3,7 @@
   /* Light theme variables */
   --bg-color: #eee;
   --text-color: #222;
+  --footer-text-color: #fff;
   --link-color: #4faf00;
   --link-visited: #577c37;
   --header-color: #3b5526;
@@ -417,7 +418,7 @@ header img {
 
 /* Footer */
 footer {
-  color: var(--text-color);
+  color: var(--footer-text-color);
   background: var(--nav-bg);
   border-color: var(--border-color);
   padding: 0.25em 0.5em;
@@ -704,7 +705,7 @@ footer a:active {
 
 [data-theme="dark"] footer {
   background-color: var(--nav-bg);
-  color: var(--text-color);
+  color: var(--footer-text-color);
   border-color: var(--border-color);
 }
 


### PR DESCRIPTION
I'm not sure how I missed it, but the light mode text was broken via #25 when it was adapted for dark mode.

<details>
<summary>Before</summary>

<img width="1260" height="122" alt="image" src="https://github.com/user-attachments/assets/de42ec02-31c9-4e6b-9a3d-1cc5dc44d972" />


</details>

<details>
<summary>After (i.e., restored to the previous snapshot before dark mode)</summary>

<img width="1241" height="120" alt="image" src="https://github.com/user-attachments/assets/9165af9d-b428-49a1-a379-3d673b5a8f53" />


</details>

xref: #44